### PR TITLE
[#85] 카드 삭제 요청시 카드보드가 카드에게 요청을 전달한다.

### DIFF
--- a/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardBoardController.java
@@ -6,6 +6,7 @@ import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -13,8 +14,10 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+import org.wedding.adapter.in.web.dto.DeleteCardRequest;
 import org.wedding.adapter.in.web.dto.ModifyCardRequest;
 import org.wedding.adapter.out.dto.CardsResponse;
+import org.wedding.application.port.in.command.card.DeleteCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
 import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.ReadCardCommand;
@@ -73,6 +76,20 @@ public class CardBoardController {
         requestCardUseCase.requestModifyCard(cardId, command);
 
         ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "카드가 수정되었습니다.");
+        return new ResponseEntity<>(response, response.status());
+    }
+
+    @DeleteMapping("{cardId}")
+    @Operation(summary = "카드 삭제", description = "카드보드가 카드에게 삭제를 요청한다")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<ApiResponse<Void>> deleteCard(
+        @RequestBody @Valid DeleteCardRequest request) {
+        int userId = (int) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        DeleteCardCommand command = new DeleteCardCommand(userId, request.cardId());
+
+        requestCardUseCase.requestDeleteCard(command);
+
+        ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "카드가 삭제되었습니다.");
         return new ResponseEntity<>(response, response.status());
     }
 }

--- a/src/main/java/org/wedding/adapter/in/web/CardController.java
+++ b/src/main/java/org/wedding/adapter/in/web/CardController.java
@@ -3,7 +3,6 @@ package org.wedding.adapter.in.web;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -66,16 +65,5 @@ public class CardController {
 
         ReadCardResponse response = readCardUseCase.readCardsByCardTitle(cardTitle);
         return new ResponseEntity<>(response, HttpStatus.OK);
-    }
-
-    @DeleteMapping("/{cardId}")
-    @Operation(summary = "카드 삭제", description = "카드 삭제")
-    @ResponseStatus(HttpStatus.OK)
-    public ResponseEntity<ApiResponse<Void>> deleteCard(@PathVariable int cardId) {
-
-        deleteCardUseCase.deleteCard(cardId);
-
-        ApiResponse<Void> response = ApiResponse.successApiResponse(HttpStatus.OK, "카드가 삭제되었습니다.");
-        return new ResponseEntity<>(response, response.status());
     }
 }

--- a/src/main/java/org/wedding/adapter/in/web/dto/DeleteCardRequest.java
+++ b/src/main/java/org/wedding/adapter/in/web/dto/DeleteCardRequest.java
@@ -1,0 +1,14 @@
+package org.wedding.adapter.in.web.dto;
+
+public record DeleteCardRequest(
+    int cardId
+) {
+
+        public String toString() {
+            return """
+                DeleteCardRequest{
+                    cardId='%s'
+                }
+                """.formatted(cardId);
+        }
+}

--- a/src/main/java/org/wedding/application/port/in/command/card/DeleteCardCommand.java
+++ b/src/main/java/org/wedding/application/port/in/command/card/DeleteCardCommand.java
@@ -1,0 +1,16 @@
+package org.wedding.application.port.in.command.card;
+
+public record DeleteCardCommand(
+    int userId,
+    int cardId
+) {
+
+    public String toString() {
+        return """
+            DeleteCardCommand{
+                userId='%s',
+                cardId='%s'
+            }
+            """.formatted(userId, cardId);
+    }
+}

--- a/src/main/java/org/wedding/application/port/in/usecase/cardboard/RequestCardUseCase.java
+++ b/src/main/java/org/wedding/application/port/in/usecase/cardboard/RequestCardUseCase.java
@@ -1,8 +1,10 @@
 package org.wedding.application.port.in.usecase.cardboard;
 
+import org.wedding.application.port.in.command.card.DeleteCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
 
 public interface RequestCardUseCase {
 
     void requestModifyCard(int cardId, ModifyCardCommand command);
+    void requestDeleteCard(DeleteCardCommand command);
 }

--- a/src/main/java/org/wedding/application/service/CardBoardService.java
+++ b/src/main/java/org/wedding/application/service/CardBoardService.java
@@ -6,7 +6,9 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.wedding.application.port.in.command.card.DeleteCardCommand;
 import org.wedding.application.port.in.command.card.ModifyCardCommand;
+import org.wedding.application.port.in.usecase.card.DeleteCardUseCase;
 import org.wedding.application.port.in.usecase.card.ModifyCardUseCase;
 import org.wedding.application.port.in.usecase.cardboard.CardBoardUseCase;
 import org.wedding.application.port.in.command.cardboard.CreateCardBoardCommand;
@@ -33,6 +35,7 @@ public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidato
     private final CardBoardRepository cardBoardRepository;
     private final ReadCardUseCase readCardUseCase;
     private final ModifyCardUseCase modifyCardUseCase;
+    private final DeleteCardUseCase deleteCardUseCase;
 
     @Override
     public void createCardBoard(CreateCardBoardCommand command) {
@@ -70,6 +73,15 @@ public class CardBoardService implements CardBoardUseCase, CardOwnerShipValidato
             throw new CardBoardException(CardBoardError.CARD_OWNER_NOT_MATCH);
         }
         modifyCardUseCase.modifyCard(cardId, command);
+    }
+
+    @Transactional
+    @Override
+    public void requestDeleteCard(DeleteCardCommand command) {
+        if(!checkCardOwner(command.userId(), command.cardId())) {
+            throw new CardBoardException(CardBoardError.CARD_OWNER_NOT_MATCH);
+        }
+        deleteCardUseCase.deleteCard(command.cardId());
     }
 
     @Transactional(readOnly = true)

--- a/src/test/java/org/wedding/adapter/in/web/DeleteCardIntegTest.java
+++ b/src/test/java/org/wedding/adapter/in/web/DeleteCardIntegTest.java
@@ -1,0 +1,84 @@
+package org.wedding.adapter.in.web;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.transaction.annotation.Transactional;
+import org.wedding.adapter.in.web.dto.DeleteCardRequest;
+import org.wedding.common.security.JwtUtils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+public class DeleteCardIntegTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    private String token;
+
+    @BeforeEach
+    void setUp() {
+        int userId = 0; // 테스트용 사용자 ID
+        token = JwtUtils.generateToken(userId);
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken (
+            userId, null, Collections.emptyList());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+    }
+
+    @DisplayName("카드 삭제 성공")
+    @Test
+    void deleteCardSuccess() throws Exception {
+        // given
+        int cardId = 0; // 테스트용 카드 ID
+        DeleteCardRequest deleteCardRequest = new DeleteCardRequest(cardId);
+        String request = objectMapper.writeValueAsString(deleteCardRequest);
+
+        // when
+        ResultActions resultActions =
+            mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/cardboard/{cardId}", cardId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(request));
+
+        // then
+        resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("카드가 삭제되었습니다."));
+    }
+
+    @DisplayName("카드 삭제 실패")
+    @Test
+    void deleteCardFail() throws Exception {
+        // given
+        int cardId = -1; // 존재하지 않는 카드ID
+        DeleteCardRequest deleteCardRequest = new DeleteCardRequest(cardId);
+        String request = objectMapper.writeValueAsString(deleteCardRequest);
+
+        // when
+        ResultActions resultActions =
+            mockMvc.perform(MockMvcRequestBuilders.delete("/api/v1/cardboard/{cardId}", cardId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(request));
+
+        // then
+        resultActions.andExpect(status().isForbidden())
+            .andExpect(jsonPath("$.message").value("카드 소유자가 일치하지 않습니다."));
+    }
+}


### PR DESCRIPTION
### Isuue Number:
#85 
## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 카드를 관라히는 카드보드가 클라이언트의 요청을 직접적으로 받는다.
- 카드는 카드보드의 요청을 이행한다. 

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.


## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.