### PR TITLE
[#106] utf-8 인코딩 설정 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,6 +23,12 @@ mybatis:
   configuration:
     map-underscore-to-camel-case: true
   type-handlers-package: org.wedding.adapter.out.persistence.mybatis
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true
 
 ---
 
@@ -52,3 +58,9 @@ mybatis:
   configuration:
     map-underscore-to-camel-case: true
   type-handlers-package: org.wedding.adapter.out.persistence.mybatis
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      enabled: true
+      force: true


### PR DESCRIPTION
### Issue Number: #106 

## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 스프링 설정에 UTF-8 인코딩을 강제하여 클라이언트가 GET할 때, 한글이 깨지는 버그를 해결한다.

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.


## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.