### PR TITLE
[#107] 카드 수정 시 카드 제목만 수정되는 버그 재현을 위한 통합 테스트 시나리오 추가 (프론트 이슈로 밝혀짐)

### DIFF
--- a/src/test/java/org/wedding/adapter/in/web/ModifyCardIntegTest.java
+++ b/src/test/java/org/wedding/adapter/in/web/ModifyCardIntegTest.java
@@ -39,22 +39,22 @@ public class ModifyCardIntegTest {
     void setUp() {
         int userId = 0; // 테스트용 사용자 ID
         token = JwtUtils.generateToken(userId);
-        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken (
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
             userId, null, Collections.emptyList());
         SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
-    @DisplayName("카드 수정")
+    @DisplayName("카드의 모든 인자 수정")
     @Test
-    void modifyCard() throws Exception {
+    void modifyCardTitle() throws Exception {
         // given
         int cardId = 0; // 테스트용 카드 ID
         CardStatus modifyStatus = CardStatus.DONE;
         ModifyCardRequest modifyCardRequest = ModifyCardRequest.builder()
-                .cardTitle(Optional.of("카드 제목 수정"))
-                .budget(Optional.of(10000L))
-                .cardStatus(Optional.of(modifyStatus))
-                .build();
+            .cardTitle(Optional.of("카드 제목 수정"))
+            .budget(Optional.of(10000L))
+            .cardStatus(Optional.of(modifyStatus))
+            .build();
 
         String request = objectMapper.writeValueAsString(modifyCardRequest);
 

--- a/src/test/java/org/wedding/adapter/in/web/ModifyCardIntegTest.java
+++ b/src/test/java/org/wedding/adapter/in/web/ModifyCardIntegTest.java
@@ -69,4 +69,28 @@ public class ModifyCardIntegTest {
         resultActions.andExpect(status().isOk())
             .andExpect(jsonPath("$.message").value("카드가 수정되었습니다."));
     }
+
+    @DisplayName("카드 상태만 수정")
+    @Test
+    void modifyCardStatus() throws Exception {
+        // given
+        int cardId = 0; // 테스트용 카드 ID
+        CardStatus modifyStatus = CardStatus.DONE;
+        ModifyCardRequest modifyCardRequest = ModifyCardRequest.builder()
+            .cardStatus(Optional.of(modifyStatus))
+            .build();
+
+        String request = objectMapper.writeValueAsString(modifyCardRequest);
+
+        // when
+        ResultActions resultActions =
+            mockMvc.perform(MockMvcRequestBuilders.patch("/api/v1/cardboard/{cardId}", cardId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .header("Authorization", "Bearer " + token)
+                .content(request));
+
+        // then
+        resultActions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.message").value("카드가 수정되었습니다."));
+    }
 }

--- a/src/test/java/org/wedding/application/service/MailSenderTestConfig.java
+++ b/src/test/java/org/wedding/application/service/MailSenderTestConfig.java
@@ -1,0 +1,18 @@
+package org.wedding.application.service;
+
+import static org.mockito.Mockito.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.mail.javamail.JavaMailSender;
+
+@Configuration
+public class MailSenderTestConfig {
+
+    @Bean
+    @Primary
+    public JavaMailSender javaMailSender() {
+        return mock(JavaMailSender.class);
+    }
+}


### PR DESCRIPTION
### Isuue Number: #107 

## 요약
변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요.

- 개발 환경에서 페이지에서 카드 수정 시 카드 제목에 변경이 없으면 카드 수정이 되지 않는 버그 발생
- 백엔드는 카드의 각 인자들 하나 씩만 변경해도 수정 가능하도록 로직을 짰었음
- 버그 재현을 위해 카드 수정 테스트 로직을 더 세분화함
  - 그러나 통합테스트에는 버그가 재현되지 않아 프론트 이슈임을 의심함
  - 프론트에서 카드 수정 시 제목을 필수값으로 받아서 제목에 변경이 없으면 카드 수정이 실패되는 거였음
- 프론트에서 문제를 해결하여 해당 PR은 테스트 추가를 마무리로 종료함 

## 더 자세히
각 요약에 대해 더 자세히 작성해주세요.


## 체크리스트
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다. 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [x] Assignees를 지정했습니다.